### PR TITLE
Place circuit board design files under CC-BY-SA license.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -50,7 +50,36 @@ manner, but not in any way that suggests the licensor endorses you or your use.
 
 
 Python Code & snippets
-
+--------
 Will have the the license included in the top of the file. If you can not tell, it is released under the LICENSE_ADI_BSD terms.
 
 
+Printed circuit board design files
+--------
+Circuit boards in this repository are intended to accompany various lab
+exercises, articles, or other instructions on the ADI wiki. A design typically
+includes a schematic file, a printed circuit board file, component library
+file(s), and various helper files. Manufacturing files(gerber and drill files),
+as well as PDFs or image files, may also be included for convenience.
+
+These works are licensed under a Creative Commons Attribution-ShareAlike 4.0
+International License.
+
+https://creativecommons.org/licenses/by-sa/4.0/
+
+You are free to:
+Share — copy and redistribute the material in any medium or format for any
+purpose, even commercially. Adapt — remix, transform, and build upon the
+material for any purpose, even commercially.
+
+The licensor cannot revoke these freedoms as long as you follow the license
+terms.
+
+Under the following terms:
+Attribution - You must give appropriate credit , provide a link to the license,
+and indicate if changes were made . You may do so in any reasonable manner,
+but not in any way that suggests the licensor endorses you or your use.
+ShareAlike - If you remix, transform, or build upon the material, you must
+distribute your contributions under the same license as the original. No
+additional restrictions - You may not apply legal terms or technological
+measures that legally restrict others from doing anything the license permits.


### PR DESCRIPTION
Put accessory board design files under Creative Commons BY ShareAlike license, per recommendation from licensing dept.